### PR TITLE
Add support for multiple codec format

### DIFF
--- a/src/OpenJpegDotNet/IO/Reader.cs
+++ b/src/OpenJpegDotNet/IO/Reader.cs
@@ -89,7 +89,7 @@ namespace OpenJpegDotNet.IO
 
         #region Methods
 
-        public bool ReadHeader()
+        public bool ReadHeader(CodecFormat codecFormat = CodecFormat.J2k)
         {
             this._Codec?.Dispose();
             this._DecompressionParameters?.Dispose();
@@ -99,9 +99,7 @@ namespace OpenJpegDotNet.IO
             this._DecompressionParameters = null;
             this._Image = null;
 
-            // ToDo: Support to change format?
-            this._Codec = OpenJpeg.CreateDecompress(CodecFormat.J2k);
-            //this._Codec = OpenJpeg.CreateDecompress(CodecFormat.Jp2);
+            this._Codec = OpenJpeg.CreateDecompress(codecFormat);
             this._DecompressionParameters = new DecompressionParameters();
             OpenJpeg.SetDefaultDecoderParameters(this._DecompressionParameters);
 


### PR DESCRIPTION
Thanks a lot for the amazing work here and for continuing improving the OpenJpegDotNet package.

I'm planning to use this fork of the library to decode JPX images contained in pdf documents. In order to do so I need to use the Jp2 codec format (instead of the j2k default one).

Let me know if any questions